### PR TITLE
Setting `userAbout` field to `Nothing` if empty

### DIFF
--- a/hackernews.cabal
+++ b/hackernews.cabal
@@ -1,5 +1,5 @@
 name:                hackernews
-version:             0.2.2.1
+version:             0.2.2.2
 description:         API for news.ycombinator.com
 license:             MIT
 synopsis:            API for Hacker News

--- a/src/Web/HackerNews/User.hs
+++ b/src/Web/HackerNews/User.hs
@@ -8,7 +8,7 @@ import           Data.Aeson          (FromJSON (parseJSON), Value (Object),
 import           Data.Text           (Text)
 import           Data.Time           (UTCTime)
 
-import           Web.HackerNews.Util (fromSeconds)
+import           Web.HackerNews.Util (fromSeconds, monoidToMaybe)
 
 ------------------------------------------------------------------------------
 -- | Types
@@ -30,7 +30,7 @@ newtype UserId
 -- | JSON Instances
 instance FromJSON User where
   parseJSON (Object o) =
-     User <$> o .:? "about"
+     User <$> ((monoidToMaybe =<<) <$> (o .:? "about"))
           <*> (fromSeconds <$> o .: "created")
           <*> o .: "delay"
           <*> (UserId <$> o .: "id")

--- a/src/Web/HackerNews/Util.hs
+++ b/src/Web/HackerNews/Util.hs
@@ -4,6 +4,7 @@ import qualified Data.Text as T
 import           Data.Text    (Text)
 import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import           Data.Time (UTCTime)
+import           Data.Monoid (Monoid, mempty)
 
 ------------------------------------------------------------------------------
 -- | Convert `Integer` to `UTCTime`
@@ -15,4 +16,7 @@ fromSeconds = posixSecondsToUTCTime . fromInteger
 toText :: Show a => a -> Text
 toText = T.pack . show
 
-
+-- | Turns empty monoids into Nothing
+-- | @Data.Maybe.listToMaybe@ generalized for monoids
+monoidToMaybe :: (Eq a, Monoid a) => a -> Maybe a
+monoidToMaybe m = if m == mempty then Nothing else Just m


### PR DESCRIPTION
Some HN users (e.g. zinfandel) simply doesn't have `about` field, such
case results to `Nothing` in User's record. Others (e.g. root) have it but it's
empty. It seems that it's a good idea to turn such empty fields into `Nothing`.
