### PR TITLE
Wreq backend

### DIFF
--- a/examples/Examples.hs
+++ b/examples/Examples.hs
@@ -1,0 +1,58 @@
+-- | You should have async, wreq, timeit and hackernews in order to compile this
+module Examples where
+
+import Control.Concurrent.Async (mapConcurrently)
+import Control.Monad (forM_)
+import System.TimeIt (timeIt)
+
+import Web.HackerNews
+
+import Network.Wreq (withManager)
+
+ensureJust :: Maybe a -> IO ()
+ensureJust Nothing = error "Request Failed."
+ensureJust (Just _) = return ()
+
+-- | Each example gets a number of items and verifies that all of them are @Just Something@
+main :: IO ()
+main = do
+    -- | Ids of items that we gonna fetch
+    let itemIds = map ItemId [1..10]
+    
+    ---------------------------------------------------------------------------
+    
+    -- | Here we open a new connection for each request
+    putStrLn "[[[ Fetching 10 Items consequently ]]]"
+    timeIt $ forM_ itemIds $ \id' -> do
+    	putStr $ "Fetching: " ++ show id'
+    	getItem id'
+    	putStrLn "\t\t[DONE]"
+    
+    ---------------------------------------------------------------------------
+    
+    -- | Opening a new connection is an expensive opperation, fortunately we can
+    -- | share it. withManager gives us `Options` which has a manager that manages
+    -- | our connections. Manager would open a new connection if it's necessary
+    -- | and it would use an existing one in case if it's possible. In result
+    -- | CPU time is reduced greatly. The real time is reduced slightly.
+    putStrLn "[[[ Fetching 10 Items consequently with shared manager ]]]"
+    timeIt $ withManager $ \opts -> forM_ itemIds $ \id' -> do
+    	putStr $ "Fetching: " ++ show id'
+    	getItemWith opts id'
+    	putStrLn "\t\t[DONE]"
+    
+    ---------------------------------------------------------------------------
+    
+    -- | We also can share one manager across multiple threads. Making requests
+    -- | concurrently would greatly reduce real time.
+    putStrLn "[[[ Fetching 10 Items concurrently with shared manager ]]]"
+    timeIt $ withManager $ \opts -> mapConcurrently (getItemWith opts) itemIds >> return ()
+    
+    ---------------------------------------------------------------------------
+    
+    -- | I really enjoy watching how it works concurrently. How it loads my 
+    -- | network. So, one more time. 100 concurent requests.
+    let itemIds = map ItemId [1..100]
+    putStrLn "[[[ Fetching 100 Items concurrently with shared manager ]]]"
+    timeIt $ withManager $ \opts -> mapConcurrently (getItemWith opts) itemIds >> return ()
+	

--- a/examples/Simple.hs
+++ b/examples/Simple.hs
@@ -1,0 +1,7 @@
+module Simple where
+
+import Web.HackerNews
+
+-- | Simply get an item with default options and print it
+main :: IO ()
+main = print =<< getItem (ItemId 999)

--- a/hackernews.cabal
+++ b/hackernews.cabal
@@ -26,16 +26,16 @@ library
                      , Web.HackerNews.Util
                      , Web.HackerNews.Endpoint
   hs-source-dirs:      src
-  build-depends:       HsOpenSSL    >= 0.10.5
-                     , aeson        >= 0.8.0.1
+  build-depends:       aeson        >= 0.8.0.1
                      , attoparsec   >= 0.12.1.2
                      , base         >= 4.7 && <4.8
                      , bytestring   >= 0.10.4.0
-                     , http-streams >= 0.7.2.2
-                     , io-streams   >= 1.1.4.6
                      , text         >= 1.2.0.0
                      , time         >= 1.4.2
                      , transformers >= 0.3.0.0
+                     , wreq         >= 0.2
+                     , lens         >= 4.4
+                     , lens-aeson   >= 1
   default-language:    Haskell2010
 
 Test-Suite tests
@@ -47,6 +47,7 @@ Test-Suite tests
                        , hackernews
                        , hspec >= 1.11.4
                        , transformers
+                       , wreq
     default-language:    Haskell2010
     ghc-options:         -Wall
 

--- a/src/Web/HackerNews.hs
+++ b/src/Web/HackerNews.hs
@@ -2,25 +2,15 @@
 module Web.HackerNews
        ( -- * API Calls
          getItem
-       , getItemWith
        , getStory
-       , getStoryWith
        , getComment
-       , getCommentWith
        , getPoll
-       , getPollWith
        , getPollOpt
-       , getPollOptWith
        , getUser
-       , getUserWith
        , getJob
-       , getJobWith
        , getTopStories
-       , getTopStoriesWith
        , getMaxItem
-       , getMaxItemWith
        , getUpdates
-       , getUpdatesWith
          -- * Types
        , Item      (..)
        , ItemId    (..)
@@ -46,91 +36,51 @@ import           Network.Wreq (Options)
 import           Web.HackerNews.Types
 
 ------------------------------------------------------------------------------
--- | Retrieve a `Item` by `ItemId`
-getItem :: ItemId -> IO (Maybe Item)
-getItem = getEndpoint
-
 -- | Retrieve a `Item` by `ItemId` using provided `Options`
-getItemWith :: Options -> ItemId -> IO (Maybe Item)
-getItemWith = getEndpointWith
+getItem :: Options -> ItemId -> IO (Maybe Item)
+getItem = getEndpointWith
 
 ------------------------------------------------------------------------------
--- | Retrieve a `Story` by `StoryId`
-getStory :: StoryId -> IO (Maybe Story)
-getStory = getEndpoint
-
 -- | Retrieve a `Story` by `StoryId` using provided `Options`
-getStoryWith :: Options -> StoryId -> IO (Maybe Story)
-getStoryWith = getEndpointWith
+getStory :: Options -> StoryId -> IO (Maybe Story)
+getStory = getEndpointWith
 
 ------------------------------------------------------------------------------
--- | Retrieve a `Comment` by `CommentId`
-getComment :: CommentId -> IO (Maybe Comment)
-getComment = getEndpoint
-
 -- | Retrieve a `Comment` by `CommentId` using provided `Options`
-getCommentWith :: Options -> CommentId -> IO (Maybe Comment)
-getCommentWith = getEndpointWith
+getComment :: Options -> CommentId -> IO (Maybe Comment)
+getComment = getEndpointWith
 
 ------------------------------------------------------------------------------
--- | Retrieve a `Poll` by `PollId`
-getPoll :: PollId -> IO (Maybe Poll)
-getPoll = getEndpoint
-
 -- | Retrieve a `Poll` by `PollId` using provided `Options`
-getPollWith :: Options -> PollId -> IO (Maybe Poll)
-getPollWith = getEndpointWith
+getPoll :: Options -> PollId -> IO (Maybe Poll)
+getPoll = getEndpointWith
 
 ------------------------------------------------------------------------------
--- | Retrieve a `PollOpt` by `PollOptId`
-getPollOpt :: PollOptId -> IO (Maybe PollOpt)
-getPollOpt = getEndpoint
-
 -- | Retrieve a `PollOpt` by `PollOptId` using provided `Options`
-getPollOptWith :: Options -> PollOptId -> IO (Maybe PollOpt)
-getPollOptWith = getEndpointWith
+getPollOpt :: Options -> PollOptId -> IO (Maybe PollOpt)
+getPollOpt = getEndpointWith
 
 ------------------------------------------------------------------------------
--- | Retrieve a `User` by `UserId`
-getUser :: UserId -> IO (Maybe User)
-getUser = getEndpoint
-
 -- | Retrieve a `User` by `UserId` using provided `Options`
-getUserWith :: Options -> UserId -> IO (Maybe User)
-getUserWith = getEndpointWith
+getUser :: Options -> UserId -> IO (Maybe User)
+getUser = getEndpointWith
 
 ------------------------------------------------------------------------------
--- | Retrieve a Job
-getJob :: JobId -> IO (Maybe Job)
-getJob = getEndpoint
-
 -- | Retrieve a Job using provided `Options`
-getJobWith :: Options -> JobId -> IO (Maybe Job)
-getJobWith = getEndpointWith
+getJob :: Options -> JobId -> IO (Maybe Job)
+getJob = getEndpointWith
 
 ------------------------------------------------------------------------------
--- | Retrieve the Top Stories on Hacker News
-getTopStories :: IO (Maybe TopStories)
-getTopStories = getEndpoint TopStoriesId
-
 -- | Retrieve the Top Stories on Hacker News using provided `Options`
-getTopStoriesWith :: Options -> IO (Maybe TopStories)
-getTopStoriesWith = flip getEndpointWith TopStoriesId
+getTopStories :: Options -> IO (Maybe TopStories)
+getTopStories = flip getEndpointWith TopStoriesId
 
 ------------------------------------------------------------------------------
--- | Retrieve the largest ItemId
-getMaxItem :: IO (Maybe MaxItem)
-getMaxItem = getEndpoint MaxItemId
-
 -- | Retrieve the largest ItemId using provided `Options`
-getMaxItemWith :: Options -> IO (Maybe MaxItem)
-getMaxItemWith = flip getEndpointWith MaxItemId
+getMaxItem :: Options -> IO (Maybe MaxItem)
+getMaxItem = flip getEndpointWith MaxItemId
 
 ------------------------------------------------------------------------------
--- | Retrieve the latest updates
-getUpdates :: IO (Maybe Update)
-getUpdates = getEndpoint UpdateId
-
 -- | Retrieve the latest updates using provided `Options`
-getUpdatesWith :: Options -> IO (Maybe Update)
-getUpdatesWith = flip getEndpointWith UpdateId
+getUpdates :: Options -> IO (Maybe Update)
+getUpdates = flip getEndpointWith UpdateId

--- a/src/Web/HackerNews.hs
+++ b/src/Web/HackerNews.hs
@@ -34,6 +34,7 @@ module Web.HackerNews
 import           Network.Wreq (Options)
 
 import           Web.HackerNews.Types
+import           Web.HackerNews.Endpoint (getEndpointWith)
 
 ------------------------------------------------------------------------------
 -- | Retrieve a `Item` by `ItemId` using provided `Options`

--- a/src/Web/HackerNews.hs
+++ b/src/Web/HackerNews.hs
@@ -1,20 +1,27 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Web.HackerNews
-       ( -- * Hacker News Monad
-         hackerNews
-         -- * API Calls
-       , getItem
+       ( -- * API Calls
+         getItem
+       , getItemWith
        , getStory
+       , getStoryWith
        , getComment
+       , getCommentWith
        , getPoll
+       , getPollWith
        , getPollOpt
+       , getPollOptWith
        , getUser
+       , getUserWith
        , getJob
+       , getJobWith
        , getTopStories
+       , getTopStoriesWith
        , getMaxItem
+       , getMaxItemWith
        , getUpdates
+       , getUpdatesWith
          -- * Types
-       , HackerNews
        , Item      (..)
        , ItemId    (..)
        , Comment   (..)
@@ -34,57 +41,96 @@ module Web.HackerNews
        , TopStories
        ) where
 
-import           Web.HackerNews.Types
-import           Web.HackerNews.Client (HackerNews, hackerNews)
+import           Network.Wreq (Options)
 
+import           Web.HackerNews.Types
 
 ------------------------------------------------------------------------------
 -- | Retrieve a `Item` by `ItemId`
-getItem :: ItemId -> HackerNews (Maybe Item)
+getItem :: ItemId -> IO (Maybe Item)
 getItem = getEndpoint
+
+-- | Retrieve a `Item` by `ItemId` using provided `Options`
+getItemWith :: Options -> ItemId -> IO (Maybe Item)
+getItemWith = getEndpointWith
 
 ------------------------------------------------------------------------------
 -- | Retrieve a `Story` by `StoryId`
-getStory :: StoryId -> HackerNews (Maybe Story)
+getStory :: StoryId -> IO (Maybe Story)
 getStory = getEndpoint
+
+-- | Retrieve a `Story` by `StoryId` using provided `Options`
+getStoryWith :: Options -> StoryId -> IO (Maybe Story)
+getStoryWith = getEndpointWith
 
 ------------------------------------------------------------------------------
 -- | Retrieve a `Comment` by `CommentId`
-getComment :: CommentId -> HackerNews (Maybe Comment)
+getComment :: CommentId -> IO (Maybe Comment)
 getComment = getEndpoint
+
+-- | Retrieve a `Comment` by `CommentId` using provided `Options`
+getCommentWith :: Options -> CommentId -> IO (Maybe Comment)
+getCommentWith = getEndpointWith
 
 ------------------------------------------------------------------------------
 -- | Retrieve a `Poll` by `PollId`
-getPoll :: PollId -> HackerNews (Maybe Poll)
+getPoll :: PollId -> IO (Maybe Poll)
 getPoll = getEndpoint
+
+-- | Retrieve a `Poll` by `PollId` using provided `Options`
+getPollWith :: Options -> PollId -> IO (Maybe Poll)
+getPollWith = getEndpointWith
 
 ------------------------------------------------------------------------------
 -- | Retrieve a `PollOpt` by `PollOptId`
-getPollOpt :: PollOptId -> HackerNews (Maybe PollOpt)
+getPollOpt :: PollOptId -> IO (Maybe PollOpt)
 getPollOpt = getEndpoint
+
+-- | Retrieve a `PollOpt` by `PollOptId` using provided `Options`
+getPollOptWith :: Options -> PollOptId -> IO (Maybe PollOpt)
+getPollOptWith = getEndpointWith
 
 ------------------------------------------------------------------------------
 -- | Retrieve a `User` by `UserId`
-getUser :: UserId -> HackerNews (Maybe User)
+getUser :: UserId -> IO (Maybe User)
 getUser = getEndpoint
+
+-- | Retrieve a `User` by `UserId` using provided `Options`
+getUserWith :: Options -> UserId -> IO (Maybe User)
+getUserWith = getEndpointWith
 
 ------------------------------------------------------------------------------
 -- | Retrieve a Job
-getJob :: JobId -> HackerNews (Maybe Job)
+getJob :: JobId -> IO (Maybe Job)
 getJob = getEndpoint
+
+-- | Retrieve a Job using provided `Options`
+getJobWith :: Options -> JobId -> IO (Maybe Job)
+getJobWith = getEndpointWith
 
 ------------------------------------------------------------------------------
 -- | Retrieve the Top Stories on Hacker News
-getTopStories :: HackerNews (Maybe TopStories)
+getTopStories :: IO (Maybe TopStories)
 getTopStories = getEndpoint TopStoriesId
+
+-- | Retrieve the Top Stories on Hacker News using provided `Options`
+getTopStoriesWith :: Options -> IO (Maybe TopStories)
+getTopStoriesWith = flip getEndpointWith TopStoriesId
 
 ------------------------------------------------------------------------------
 -- | Retrieve the largest ItemId
-getMaxItem :: HackerNews (Maybe MaxItem)
+getMaxItem :: IO (Maybe MaxItem)
 getMaxItem = getEndpoint MaxItemId
+
+-- | Retrieve the largest ItemId using provided `Options`
+getMaxItemWith :: Options -> IO (Maybe MaxItem)
+getMaxItemWith = flip getEndpointWith MaxItemId
 
 ------------------------------------------------------------------------------
 -- | Retrieve the latest updates
-getUpdates :: HackerNews (Maybe Update)
+getUpdates :: IO (Maybe Update)
 getUpdates = getEndpoint UpdateId
 
+-- | Retrieve the latest updates using provided `Options`
+getUpdatesWith :: Options -> IO (Maybe Update)
+getUpdatesWith = flip getEndpointWith UpdateId

--- a/src/Web/HackerNews/Client.hs
+++ b/src/Web/HackerNews/Client.hs
@@ -1,60 +1,19 @@
-{-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE OverloadedStrings #-}
-module Web.HackerNews.Client
-       ( hackerNews
-       , buildHNRequest
-       , HackerNews
-       ) where
+module Web.HackerNews.Client (makeRequestWith) where
 
-import           Data.Aeson                 hiding (Result)
-import           Data.Aeson.Parser          (value)
-import           Data.Attoparsec.ByteString (parseOnly)
-import           Data.Either                (rights)
+import Control.Lens
+import Data.Aeson
+import Data.Aeson.Lens
+import Data.Text (Text, unpack)
+import Network.Wreq
 
-import           Control.Monad.IO.Class     (liftIO)
-import           Control.Monad.Trans.Reader (ReaderT, ask, runReaderT)
-import           Data.Monoid                ((<>))
-import           Data.Text                  (Text)
-import qualified Data.Text.Encoding         as T
-import           Network.Http.Client
-import           OpenSSL                    (withOpenSSL)
-import qualified System.IO.Streams          as Streams
-
-------------------------------------------------------------------------------
--- | Core Type
-type HackerNews a = ReaderT Connection IO a
-
-------------------------------------------------------------------------------
--- | HackerNews API request method
-hackerNews :: (Show a, FromJSON a) => HackerNews a -> IO a
-hackerNews requests =
-  withOpenSSL $ do
-    ctx <- baselineContextSSL
-    con <- openConnectionSSL ctx "hacker-news.firebaseio.com" 443
-    result <- runReaderT requests con 
-    closeConnection con
-    return result
-
-------------------------------------------------------------------------------
--- | Request Builder for API
-buildHNRequest :: FromJSON a => Text -> HackerNews (Maybe a)
-buildHNRequest url = do
-    con <- ask
-    liftIO $ do
-      req <- buildRequest $ do
-        http GET $ "/v0/" <> T.encodeUtf8 url <> ".json"
-        setHeader "Connection" "Keep-Alive"
-        setAccept "application/json"
-      sendRequest con req emptyBody
-      !bytes <- receiveResponse con $ const Streams.read
-      return $ case bytes of
-        Nothing -> Nothing
-        Just bs -> do
-          let xs = rights [parseOnly value bs, parseOnly json bs]
-          case xs of
-            []    -> Nothing
-            x : _ ->
-              case fromJSON x of
-                Success a -> Just a
-                _         -> Nothing
-
+makeRequestWith :: FromJSON a => Options -> Text -> IO (Maybe a)
+makeRequestWith opts path = do
+    let opts' = opts & header "Accept" .~ ["application/json"]
+    let url = "https://hacker-news.firebaseio.com/v0/" ++ unpack path ++ ".json"
+    resp <- getWith opts' url
+    return $ do
+        val <- resp ^? responseBody . _Value . to fromJSON
+        case val of
+            Error _ -> Nothing
+            (Success a) -> Just a

--- a/src/Web/HackerNews/Endpoint.hs
+++ b/src/Web/HackerNews/Endpoint.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE OverloadedStrings, MultiParamTypeClasses , FunctionalDependencies #-}
 module Web.HackerNews.Endpoint where
 
-import           Data.Aeson          (FromJSON)
-import           Data.Text           (Text, append)
+import           Data.Aeson            (FromJSON)
+import           Data.Text             (Text, append)
+import           Network.Wreq          (Options, defaults)
 
-import           Web.HackerNews.Client (HackerNews, buildHNRequest)
+import           Web.HackerNews.Client (makeRequestWith)
 import           Web.HackerNews.Util   (toText)
 
 -- | Endpoint maps the id to the returned type on a type level
@@ -17,5 +18,9 @@ itemEndpoint :: Int -> Text
 itemEndpoint = append "item/" . toText
 
 -- | Generic function for making requests
-getEndpoint :: (Endpoint a b, FromJSON b) => a -> HackerNews (Maybe b)
-getEndpoint id' = buildHNRequest $ endpoint id'
+getEndpointWith :: (Endpoint a b, FromJSON b) => Options -> a -> IO (Maybe b)
+getEndpointWith opts = makeRequestWith opts . endpoint
+
+-- | Generic function for making requests with default options
+getEndpoint :: (Endpoint a b, FromJSON b) => a -> IO (Maybe b)
+getEndpoint = makeRequestWith defaults . endpoint

--- a/src/Web/HackerNews/Endpoint.hs
+++ b/src/Web/HackerNews/Endpoint.hs
@@ -17,10 +17,6 @@ class Endpoint id resp | id -> resp where
 itemEndpoint :: Int -> Text
 itemEndpoint = append "item/" . toText
 
--- | Generic function for making requests
+-- | Generic function for making requests with provided options
 getEndpointWith :: (Endpoint a b, FromJSON b) => Options -> a -> IO (Maybe b)
 getEndpointWith opts = makeRequestWith opts . endpoint
-
--- | Generic function for making requests with default options
-getEndpoint :: (Endpoint a b, FromJSON b) => a -> IO (Maybe b)
-getEndpoint = makeRequestWith defaults . endpoint

--- a/src/Web/HackerNews/Types.hs
+++ b/src/Web/HackerNews/Types.hs
@@ -10,7 +10,7 @@ import           Web.HackerNews.User    as H
 import           Web.HackerNews.Update  as H
 import           Web.HackerNews.Job     as H
 import           Web.HackerNews.Item    as H
-import           Web.HackerNews.Endpoint as H
+import           Web.HackerNews.Endpoint as H (Endpoint(..))
 
 
 

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -5,21 +5,22 @@ import           Data.Maybe     (isJust)
 import           Test.Hspec     (it, runIO, hspec, describe)
 import           Web.HackerNews
 import           Control.Applicative
+import           Network.Wreq   (withManager)
 
 main :: IO ()
-main = hspec $ do
-  describe "Hacker News API Tests" $ do
+main = withManager $ \opts -> hspec $ do
+  describe "Hacker News API Tests" $ do 
     (story, comment, user, job, poll, pollOpt, topStories, maxItem, updates) <- 
-      runIO $ hackerNews $ (,,,,,,,,)  <$> 
-        getStory   (StoryId 8863)      <*>
-        getComment (CommentId 2921983) <*>
-        getUser    (UserId "dmjio")    <*>
-        getJob     (JobId 8437631)     <*>
-        getPoll    (PollId 126809)     <*>
-        getPollOpt (PollOptId 160705)  <*>
-        getTopStories                  <*>
-        getMaxItem                     <*>
-        getUpdates
+      runIO $ (,,,,,,,,)                        <$> 
+        getStoryWith opts   (StoryId 8863)      <*>
+        getCommentWith opts (CommentId 2921983) <*>
+        getUserWith opts    (UserId "dmjio")    <*>
+        getJobWith opts     (JobId 8437631)     <*>
+        getPollWith opts    (PollId 126809)     <*>
+        getPollOptWith opts (PollOptId 160705)  <*>
+        getTopStoriesWith opts                  <*>
+        getMaxItemWith opts                     <*>
+        getUpdatesWith opts
     it "Retrieves a Story"     $ isJust story
     it "Retrieves a Comment"   $ isJust comment
     it "Retrieves a User"      $ isJust user


### PR DESCRIPTION
I've reemplimented the backend code with wreq. For simplicity I removed everything what was there before, but I want to discuss the implementation of multiple backends if you think that it's necessary.

The biggest advantage which the wreq implimentation gives is the simplicity of sharing the connection. Connections are managed by manager which can be safely shared between concurrent threads (see examples), so the server applications can create a manager on startup and then use it for the whole application runtime (yesod users usually already have a manager for some other needs, and they can use it here).

The disadvantage is that wreq has heavy dependency, `lens`. However this can be overcomed by using `http-client` (a refactored fork of http-conduit) which `wreq` is based on. Wreq is kind of high level interface to `http-client`, with some additional features. That idea just striked me, and it seems great because depending on something as huge as `lens` for no big reason is not very good.

I haven't yet think about a go way to support multiple backends, current `wreq` implimentation is done in a way that would be ideal if wreq was the only backend, so that you can take a look.

By the way, now API has functions like `get*` and `get*With`. The second one takes `Options` (with manager inside) as an argument, first one uses default options and therefore creates a new manager on request. I consider removing those that use default options, as it's smart to use them only in case if one request is done over application life, or the requests are done with a big time interval; such usecases are very rare, so there is no need for distinct shortcuts. At the same time it would discourage the wrong usage of API when the manager is created on each request. 