### PR TITLE
Export data constructors for MaxItem and TopStories.

### DIFF
--- a/src/Web/HackerNews.hs
+++ b/src/Web/HackerNews.hs
@@ -37,8 +37,8 @@ module Web.HackerNews
        , Job       (..)
        , JobId     (..)
        , Update    (..)
-       , MaxItem
-       , TopStories
+       , MaxItem   (..)
+       , TopStories (..)
        ) where
 
 import           Web.HackerNews.Types


### PR DESCRIPTION
Without these data constructors being exported, it is not possible to get any data out of the MaxItem or TopStories types.

Other newtypes like StoryId have their constructors exported, so I think it should be okay to export the constructors for Max Item and TopStories as well.