### PR TITLE
Fix `Deleted` type

### DIFF
--- a/src/Web/HackerNews/Types.hs
+++ b/src/Web/HackerNews/Types.hs
@@ -129,7 +129,7 @@ newtype ItemId = ItemId Int
   deriving (Show, Eq, ToJSON, FromJSON, ToHttpApiData, Generic, Arbitrary)
 
 -- | `true` if the item is deleted.
-newtype Deleted = Deleted Int
+newtype Deleted = Deleted Bool
   deriving (Show, Eq, ToJSON, FromJSON, Generic, Arbitrary)
 
 -- | The type of item. One of "job", "story", "comment", "poll", or "pollopt"


### PR DESCRIPTION
`Deleted` was a wrapper around `Int` however the api returns `Bool`.

Since `deleted` field is only present when the item has actually
been deleted this problem won't manifest itself until you try to parse
a deleted item:

    *Web.HackerNews.Types> eitherDecode "{\"type\": \"story\", \"deleted\": true}" :: Either String Item
    Left "Error in $.deleted: failed to parse field deleted: expected Int, encountered Boolean"