### PR TITLE
Update to servant 0.11

### DIFF
--- a/ghc-src/Web/HackerNews.hs
+++ b/ghc-src/Web/HackerNews.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE TypeFamilies               #-}
@@ -118,7 +119,11 @@ toError :: Either ServantError ok -> Either HackerNewsError ok
 toError = first go
   where
     go :: ServantError -> HackerNewsError
+#if MIN_VERSION_servant_client(0,11,0)
+    go (FailureResponse _ Status{..} _ body) =
+#else
     go (FailureResponse Status{..} _ body) =
+#endif
       FailureResponseError statusCode (cs statusMessage) (cs body)
     go (DecodeFailure _ _ "null") = NotFound
     go (DecodeFailure err _ body) =

--- a/hackernews.cabal
+++ b/hackernews.cabal
@@ -55,7 +55,7 @@ library
                   , Web.HackerNews.Types
   hs-source-dirs: src
   build-depends:
-      servant >= 0.9 && < 0.11
+      servant >= 0.9 && < 0.12
     , QuickCheck
     , quickcheck-instances
   if impl(ghcjs)
@@ -72,7 +72,7 @@ library
     hs-source-dirs: ghc-src
     build-depends: aeson
                  , base < 5
-                 , servant-client >= 0.9 && < 0.11
+                 , servant-client >= 0.9 && < 0.12
                  , http-client == 0.5.*
                  , string-conversions == 0.4.*
                  , http-types == 0.9.*


### PR DESCRIPTION
Unfortunately this breaks compatibility with older versions of servant. I could probably use a [cpp macro](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/phases.html#standard-cpp-macros) to handle this case.