### PR TITLE
Change executable name

### DIFF
--- a/hackernews.cabal
+++ b/hackernews.cabal
@@ -17,7 +17,7 @@ extra-source-files:
     ghcjs-examples/Example.hs
     ghc-tests/Test.hs
     ghcjs-tests/Test.hs
-executable example
+executable hackernews-example
   main-is: Example.hs
   default-language: Haskell2010
   if impl (ghcjs)


### PR DESCRIPTION
Use `hackernews-example` as opposed to `example`.